### PR TITLE
feat: support UUID conversation files, filter non-conversation entries

### DIFF
--- a/src/parsers/conversation.rs
+++ b/src/parsers/conversation.rs
@@ -319,4 +319,26 @@ invalid line 3"#;
         assert_eq!(entries[1].entry_type, "assistant");
         assert_eq!(entries[2].entry_type, "user");
     }
+
+    #[test]
+    fn test_parse_conversation_fails_with_malformed_conversation_entries() {
+        // Valid JSON with type="user" but missing required ConversationEntry fields
+        // This tests the error path inside the conversation entry parsing logic
+        let mut content = String::new();
+        for i in 0..101 {
+            // Valid JSON, has type="user", but missing required "message" field
+            content.push_str(&format!(
+                r#"{{"type":"user","timestamp":{},"sessionId":"test","uuid":"uuid-{}"}}
+"#,
+                i, i
+            ));
+        }
+
+        let file = create_test_file(&content);
+        let result = parse_conversation_file(file.path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Too many consecutive parse errors"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add support for UUID.jsonl format (newer Claude Code conversations) alongside legacy agent-*.jsonl
- Filter non-conversation entry types (file-history-snapshot, summary, system) to avoid parse errors
- Add UUID pattern validation (8-4-4-4-12 hex format)
- Update docs to clarify both file formats and entry filtering

## Test plan
- [x] All existing tests pass
- [x] New test for UUID file pattern detection
- [x] New test for non-conversation entry filtering
- [x] Coverage maintains 90%+ (enforced by pre-commit)
- [x] Clippy, format, type checks pass